### PR TITLE
Implementation of read-in for general plot settings

### DIFF
--- a/sample_plot_config.ini
+++ b/sample_plot_config.ini
@@ -1,15 +1,25 @@
+[General]
+fig_width = 8
+fig_height = 7
+pop_up = no
+save_to_file = yes
+save_as = pdf
+
+[Spectra]
+spectra_histogram = yes
+
 [Geometry]
-geom_beta_tr_hist = no
+geom_beta_tr_hist = yes
 #interaction_height = no (to be implemented)
 
 [Taus]
-taus_scatter = no
-taus_pexit = no
+taus_density_beta = yes
+taus_pexit = yes
 taus_histogram = yes
 taus_overview = yes
 
 [EASOpitcal]
-eas_optical_scatter = no
+eas_optical_density = yes
 eas_optical_histogram = yes
 
 [Detector]

--- a/src/nuspacesim/simulation/eas_optical/local_plots.py
+++ b/src/nuspacesim/simulation/eas_optical/local_plots.py
@@ -42,6 +42,7 @@ def eas_optical_density(inputs, results, *args, **kwargs):
 
     _, betas, altDec, showerEnergy = inputs
     numPEs, costhetaChEff = results
+    plotting_opts = kwargs.get("kwargs")
 
     fig, ax = plt.subplots(2, 3, figsize=(15, 8), constrained_layout=True)
 
@@ -91,13 +92,21 @@ def eas_optical_density(inputs, results, *args, **kwargs):
     )
 
     fig.suptitle("EAS Optical Cherenkov properties.")
-    plt.show()
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_eas_optical_density."
+            + plotting_opts.get("save_as")
+        )
 
 
 def eas_optical_histogram(inputs, results, *args, **kwargs):
     r"""Plot some histograms"""
 
     # eas_self, betas, altDec, showerEnergy = inputs
+    plotting_opts = kwargs.get("kwargs")
     numPEs, costhetaChEff = results
 
     color = "salmon"
@@ -112,4 +121,11 @@ def eas_optical_histogram(inputs, results, *args, **kwargs):
     ax[1].set_xlabel("log(cos(θ_chEff))")
 
     fig.suptitle("EAS Optical Cherenkov property Histograms")
-    plt.show()
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_eas_optical_histogram."
+            + plotting_opts.get("save_as")
+        )

--- a/src/nuspacesim/simulation/geometry/local_plots.py
+++ b/src/nuspacesim/simulation/geometry/local_plots.py
@@ -40,9 +40,18 @@ def geom_beta_tr_hist(inputs, results, *args, **kwargs):
 
     _ = inputs
     betas, _, _ = results
+    plotting_opts = kwargs.get("kwargs")
 
+    fig = plt.figure(figsize=(8, 7), constrained_layout=True)
     plt.hist(np.degrees(betas), 50, alpha=0.75)
     plt.xlabel("beta_tr (radians)")
     plt.ylabel("frequency (counts)")
     plt.title(f"Histogram of {betas.size} Beta Angles")
-    plt.show()
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_geom_beta_tr_hist."
+            + plotting_opts.get("save_as")
+        )

--- a/src/nuspacesim/simulation/spectra/local_plots.py
+++ b/src/nuspacesim/simulation/spectra/local_plots.py
@@ -39,9 +39,10 @@ def spectra_histogram(inputs, results, *args, **kwargs):
 
     N, spectrum = inputs
     log_e_nu = results
+    plotting_opts = kwargs.get("kwargs")
 
     color = "g"
-    fig = plt.figure(figsize=(8, 7), constrained_layout=True)
+    fig = plt.figure(figsize=plotting_opts.get("figsize"), constrained_layout=True)
     ax = fig.add_subplot(211)
     ax.hist(log_e_nu, 100, log=False, facecolor=color)
     ax.set_xlabel(f"log(E_nu) of {N} events")
@@ -51,4 +52,11 @@ def spectra_histogram(inputs, results, *args, **kwargs):
     ax.set_xlabel(f"log(E_nu) of {N} events")
 
     fig.suptitle(f"Energy Spectra Histogram, Log(E_nu)\n {spectrum}")
-    plt.show()
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_spectra_histogram."
+            + plotting_opts.get("save_as")
+        )

--- a/src/nuspacesim/simulation/taus/local_plots.py
+++ b/src/nuspacesim/simulation/taus/local_plots.py
@@ -42,9 +42,9 @@ def get_profile(x, y, nbins, useStd=True, *args, **kwargs):
         x = x[~np.isnan(y)]
         y = y[~np.isnan(y)]
 
-    n, _ = np.histogram(x, bins=nbins, **kwargs)
-    sy, _ = np.histogram(x, bins=nbins, weights=y, **kwargs)
-    sy2, _ = np.histogram(x, bins=nbins, weights=y * y, **kwargs)
+    n, _ = np.histogram(x, bins=nbins)
+    sy, _ = np.histogram(x, bins=nbins, weights=y)
+    sy2, _ = np.histogram(x, bins=nbins, weights=y * y)
     mean = sy / n
     std = np.sqrt(sy2 / n - mean * mean)
     if not useStd:
@@ -60,6 +60,7 @@ def taus_density_beta(inputs, results, *args, **kwargs):
 
     _, betas, log_e_nu = inputs
     tauBeta, tauLorentz, tauEnergy, showerEnergy, tauExitProb = results
+    plotting_opts = kwargs.get("kwargs")
 
     fig, ax = plt.subplots(2, 2, figsize=(10, 8), sharex=True, constrained_layout=True)
 
@@ -82,7 +83,14 @@ def taus_density_beta(inputs, results, *args, **kwargs):
     fig.colorbar(im, ax=ax, label="Counts", format="%.0e")
 
     fig.suptitle("Tau interaction properties vs. β_tr Angles")
-    plt.show()
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_taus_density_beta."
+            + plotting_opts.get("save_as")
+        )
 
 
 def taus_histogram(inputs, results, *args, **kwargs):
@@ -93,6 +101,7 @@ def taus_histogram(inputs, results, *args, **kwargs):
 
     color = "c"
     alpha = 1
+    plotting_opts = kwargs.get("kwargs")
 
     fig, ax = plt.subplots(2, 2, constrained_layout=True)
 
@@ -106,7 +115,14 @@ def taus_histogram(inputs, results, *args, **kwargs):
     ax[1, 1].set_xlabel("log(PExit(τ))")
 
     fig.suptitle("Tau interaction property Histograms")
-    plt.show()
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_taus_histogram."
+            + plotting_opts.get("save_as")
+        )
 
 
 def taus_pexit(inputs, results, *args, **kwargs):
@@ -115,6 +131,7 @@ def taus_pexit(inputs, results, *args, **kwargs):
 
     color = "c"
     alpha = 0.1 / np.log10(betas.size)
+    plotting_opts = kwargs.get("kwargs")
 
     fig, ax = plt.subplots(1, 2, constrained_layout=True)
 
@@ -135,19 +152,28 @@ def taus_pexit(inputs, results, *args, **kwargs):
     ax[1].set_xlabel("PExit(τ)")
 
     fig.suptitle("Tau Pexit")
-    plt.show()
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_taus_pexit."
+            + plotting_opts.get("save_as")
+        )
 
 
 def taus_overview(inputs, results, *args, **kwargs):
-    r"""Overview plot for taus"""
 
+    print(kwargs)
+    r"""Overview plot for taus"""
+    plotting_opts = kwargs.get("kwargs")
     _, betas, log_e_nu = inputs
     _, tauLorentz, tauEnergy, showerEnergy, tauExitProb = results
     log_e_nu = log_e_nu + 9
     tauEnergy = tauEnergy * 1e9
     showerEnergy = showerEnergy * 1e9 * 1e8
 
-    fig, ax = plt.subplots(2, 2, figsize=(10, 8))
+    fig, ax = plt.subplots(2, 2, figsize=kwargs.get("figsize"))
     binning_b = np.arange(
         np.min(np.degrees(betas)) - 1, np.max(np.degrees(betas)) + 2, 1
     )
@@ -233,7 +259,11 @@ def taus_overview(inputs, results, *args, **kwargs):
 
     fig.suptitle("Overview of Tau interaction properties")
     fig.tight_layout()
-    plt.show()
-    # if "pop_up" in kwargs and kwargs.get("pop_up") is True:
-    #     plt.show()
-    # fig.savefig("taus_overview", format="pdf")
+    if plotting_opts.get("pop_up") is True:
+        plt.show()
+    if plotting_opts.get("save_to_file") is True:
+        fig.savefig(
+            plotting_opts.get("filename")
+            + "_taus_overview."
+            + plotting_opts.get("save_as")
+        )

--- a/src/nuspacesim/utils/decorators.py
+++ b/src/nuspacesim/utils/decorators.py
@@ -200,17 +200,17 @@ def nss_result_plot(*plot_fs):
             if isinstance(plot, str):
                 for plotf in plot_fs:
                     if plotf.__name__ == plot:
-                        plotf(args, values)
+                        plotf(args, values, **kwargs)
             elif callable(plot):
                 plot(args, values)
             elif isinstance(plot, Iterable):
                 if all(isinstance(p, str) for p in plot):
                     for plotf in plot_fs:
                         if plotf.__name__ in plot:
-                            plotf(args, values)
+                            plotf(args, values, **kwargs)
                 elif all(callable(p) for p in plot):
                     for plotf in plot:
-                        plotf(args, values)
+                        plotf(args, values, **kwargs)
             return values
 
         return wrapper_f


### PR DESCRIPTION
Here is the implementation I came up with to read-in general plot settings, such as filename, file extension, or figure size. It should work for all available methods to plot via command line (--plotconfig and --plot/--plotall). For --plotconfig the read in is automatic, for --plot/--plotall the settings have to be submitted via --plotsettings.