### PR TITLE
Added calculations for computing lat-long of points along a trajectory

### DIFF
--- a/docs/tutorial/configuration.rst
+++ b/docs/tutorial/configuration.rst
@@ -22,8 +22,8 @@ The member attributes are as follows:
 
   * **method**: Type of Detector, default = Optical
   * **altitude**: Altitude from sea level in km
-  * **ra_start**: Right Ascension (Degrees | Radians)
-  * **dec_start**: Declination (Degrees | Radians)
+  * **lat_start**: Latitude (Degrees | Radians)
+  * **long_start**: Longitude (Degrees | Radians)
   * **telescope_effective_area**: Effective area of the detector scope. Default = 2.5 m^2
   * **quantum_efficiency**: Quantum Efficiency of the detector telescope. Default = 0.2
   * **photo_electron_threshold**: Threshold Number of Photo electrons. Default = 10

--- a/src/nuspacesim/config.py
+++ b/src/nuspacesim/config.py
@@ -67,9 +67,9 @@ class DetectorCharacteristics:
     """ Type of detector: Default = Optical """
     altitude: float = 525.0
     """ Altitude from sea-level. Default = 525 KM """
-    ra_start: float = 0.0
+    lat_start: float = 0.0
     """ Right Ascencion (Degrees). Default = 0.0 """
-    dec_start: float = 0.0
+    long_start: float = 0.0
     """ Declination (Degrees). Default = 0.0 """
     telescope_effective_area: float = 2.5
     '"" Effective area of the detector telescope. Default = 2.5 sq.meters ""'
@@ -105,8 +105,8 @@ class DetectorCharacteristics:
         return {
             "method": (self.method, "Detector: Method (Optical, radio or both"),
             "detAlt": (self.altitude, "Detector: Altitude"),
-            "raStart": (self.ra_start, "Detector: Initial Right Ascencion"),
-            "decStart": (self.dec_start, "Detector: Initial Declination"),
+            "latStart": (self.lat_start, "Detector: Initial Latitude"),
+            "lonStart": (self.long_start, "Detector: Initial Longitude"),
             "telEffAr": (
                 self.telescope_effective_area,
                 "Detector: Telescope Effective Area",

--- a/src/nuspacesim/simulation/geometry/region_geometry.py
+++ b/src/nuspacesim/simulation/geometry/region_geometry.py
@@ -51,8 +51,8 @@ class RegionGeom:
             self.config.constants.earth_radius + self.config.detector.altitude
         )
 
-        self.detRA = np.radians(config.detector.ra_start)
-        self.detDec = np.radians(config.detector.dec_start)
+        self.detLat = np.radians(config.detector.lat_start)
+        self.detLong = np.radians(config.detector.long_start)
 
         alphaHorizon = np.pi / 2 - np.arccos(
             self.config.constants.earth_radius / self.core_alt
@@ -172,39 +172,65 @@ class RegionGeom:
 
         self.betaTrSubN = np.degrees(0.5 * np.pi - self.thetaTrSubN)
 
-        rsindecS = np.sin(self.config.detector.dec_start) * costhetaS - np.cos(
-            self.config.detector.dec_start
-        ) * np.sin(self.thetaS) * np.cos(self.phiS)
+        # Compute latitude and longitude of spot on the ground (based on transforming
+        # from detector's East-North_Up (ENU) frame back to the Earth-Centered-Earth-Fixed (ECEF) frame
 
-        self.decS = np.degrees(np.arcsin(rsindecS))
+        rsinlatS = np.cos(self.detLat) * np.sin(self.thetaS) * np.sin(
+            self.phiS
+        ) + np.sin(self.detLat) * np.cos(self.thetaS)
+
+        latS_rad = np.arcsin(rsinlatS)
+        self.latS = np.degrees(latS_rad)
 
         rxS = (
-            np.sin(self.config.detector.dec_start)
-            * np.cos(self.config.detector.ra_start)
-            * np.sin(self.thetaS)
-            * np.cos(self.phiS)
-            - np.sin(self.config.detector.ra_start)
+            -np.sin(self.detLong) * np.sin(self.thetaS) * np.cos(self.phiS)
+            - np.cos(self.detLong)
+            * np.sin(self.detLat)
             * np.sin(self.thetaS)
             * np.sin(self.phiS)
-            + np.cos(self.config.detector.dec_start)
-            * np.cos(self.config.detector.ra_start)
-            * np.cos(self.thetaS)
+            + np.cos(self.detLong) * np.cos(self.detLat) * np.cos(self.thetaS)
         )
 
         ryS = (
-            np.sin(self.config.detector.dec_start)
-            * np.sin(self.config.detector.ra_start)
-            * np.sin(self.thetaS)
-            * np.cos(self.phiS)
-            + np.cos(self.config.detector.ra_start)
+            np.cos(self.detLong) * np.sin(self.thetaS) * np.cos(self.phiS)
+            - np.sin(self.detLong)
+            * np.sin(self.detLat)
             * np.sin(self.thetaS)
             * np.sin(self.phiS)
-            + np.cos(self.config.detector.dec_start)
-            * np.sin(self.config.detector.ra_start)
-            * np.cos(self.thetaS)
+            + np.sin(self.detLong) * np.cos(self.detLat) * np.cos(self.thetaS)
         )
 
-        self.raS = np.degrees(np.arctan2(ryS, rxS)) % 360.0
+        longS_rad = np.arctan2(ryS, rxS)
+        self.longS = np.degrees(longS_rad) % 360.0  # Unit test possible
+
+        # Compute xy-coordinates and elevation and azimuthal angles of unit vector of the
+        # line-of-sight (los) vector between detector and spot on the ground (technically, the
+        # unit vector parallel to the los with tail at the center of the Earth) in ENU frame of the
+        # spot on the ground
+
+        self.elevAngVSubN = (
+            0.5 * np.pi - thetaNSubV
+        )  # Elevation angle of the detector w.r.t. the spot on the ground; unit test possible
+
+        xVSubN = -np.sin(longS_rad) * np.cos(self.detLat) * np.cos(
+            self.detLong
+        ) + np.cos(longS_rad) * np.cos(self.detLat) * np.sin(self.detLong)
+
+        yVSubN = (
+            -np.cos(longS_rad)
+            * np.sin(latS_rad)
+            * np.cos(self.detLat)
+            * np.cos(self.detLong)
+            - np.sin(longS_rad)
+            * np.sin(latS_rad)
+            * np.cos(self.detLat)
+            * np.sin(self.detLong)
+            + np.cos(latS_rad) * np.sin(self.detLat)
+        )
+
+        self.aziAngVSubN = np.arctan2(
+            yVSubN, xVSubN
+        )  # Azimuthal angle of the detector w.r.t. the spot on the ground
 
         self.event_mask = np.logical_and(self.costhetaTrSubN >= 0, self.betaTrSubN < 42)
 
@@ -220,6 +246,9 @@ class RegionGeom:
         """View angles for valid events."""
         return self.thetaTrSubV[self.event_mask]
 
+    def phis(self):
+        return self.phiTrSubV[self.event_mask]
+
     def pathLens(self):
         """View angles for valid events."""
         # pathLenArr = super().evArray["losPathLen"][super().evMasknpArray]
@@ -234,6 +263,92 @@ class RegionGeom:
 
     def valid_costhetaTrSubV(self):
         return self.costhetaTrSubV[self.event_mask]
+
+    def valid_longS(self):
+        return self.longS[self.event_mask]
+
+    def valid_latS(self):
+        return self.latS[self.event_mask]
+
+    def valid_longS_rad(self):
+        return np.radians(self.valid_longS())
+
+    def valid_latS_rad(self):
+        return np.radians(self.valid_latS())
+
+    def valid_elevAngVSubN(self):
+        return self.elevAngVSubN[self.event_mask]
+
+    def valid_aziAngVSubN(self):
+        return self.aziAngVSubN[self.event_mask]
+
+    def find_lat_long_along_traj(self, dist_along_traj):
+        # Compute xyz-coordinates in ENU frame of los between detector and spot on the ground
+
+        xPath_v = dist_along_traj * np.sin(self.thetas()) * np.cos(self.phis())
+
+        yPath_v = dist_along_traj * np.sin(self.thetas()) * np.sin(
+            self.phis()
+        ) + self.config.constants.earth_radius * np.cos(self.valid_elevAngVSubN())
+
+        zPath_v = dist_along_traj * np.cos(
+            self.thetas()
+        ) + self.config.constants.earth_radius * np.sin(self.valid_elevAngVSubN())
+
+        # Compute xyz-coordinates in the spot's ENU frame (accomplished by transforming from
+        # the los ENU frame to the spot's ENU frame)
+
+        xPath_n = (
+            -np.sin(self.valid_aziAngVSubN()) * xPath_v
+            - np.cos(self.valid_aziAngVSubN())
+            * np.sin(self.valid_elevAngVSubN())
+            * yPath_v
+            + np.cos(self.valid_aziAngVSubN())
+            * np.cos(self.valid_elevAngVSubN())
+            * zPath_v
+        )
+
+        yPath_n = (
+            np.cos(self.valid_aziAngVSubN()) * xPath_v
+            - np.sin(self.valid_aziAngVSubN())
+            * np.sin(self.valid_elevAngVSubN())
+            * yPath_v
+            + np.sin(self.valid_aziAngVSubN())
+            * np.cos(self.valid_elevAngVSubN())
+            * zPath_v
+        )
+
+        zPath_n = (
+            np.cos(self.valid_elevAngVSubN()) * yPath_v
+            + np.sin(self.valid_elevAngVSubN()) * zPath_v
+        )
+
+        # Compute xyz-coordinates in the ECEF frame (accomplished by transforming from the spot's
+        # ENU frame to the ECEF frame)
+
+        xPath_ECEF = (
+            -np.sin(self.valid_longS_rad()) * xPath_n
+            - np.cos(self.valid_longS_rad()) * np.sin(self.valid_latS_rad()) * yPath_n
+            + np.cos(self.valid_longS_rad()) * np.cos(self.valid_latS_rad()) * zPath_n
+        )
+
+        yPath_ECEF = (
+            np.cos(self.valid_longS_rad()) * xPath_n
+            - np.sin(self.valid_longS_rad()) * np.sin(self.valid_latS_rad()) * yPath_n
+            + np.sin(self.valid_longS_rad()) * np.cos(self.valid_latS_rad()) * zPath_n
+        )
+
+        zPath_ECEF = (
+            np.cos(self.valid_latS_rad()) * yPath_n
+            + np.sin(self.valid_latS_rad()) * zPath_n
+        )
+
+        dist2EarthCenter = np.sqrt(xPath_ECEF**2 + yPath_ECEF**2 + zPath_ECEF**2)
+
+        latPath = np.arcsin(zPath_ECEF / dist2EarthCenter)
+        longPath = np.arctan2(yPath_ECEF, xPath_ECEF)
+
+        return latPath, longPath
 
     @decorators.nss_result_plot(geom_beta_tr_hist)
     @decorators.nss_result_store("beta_rad", "theta_rad", "path_len")

--- a/src/nuspacesim/xml_config/config_xml_schema.py
+++ b/src/nuspacesim/xml_config/config_xml_schema.py
@@ -142,8 +142,8 @@ xsd = StringIO(
             <xs:element name="TelescopeEffectiveArea" type="AreaType"/>
             <xs:element name="PhotoElectronThreshold" type="PETType"/>
             <xs:element name="DetectorAltitude" type="DistType"/>
-            <xs:element name="InitialDetectorRightAscension" type="AngleType"/>
-            <xs:element name="InitialDetectorDeclination" type="AngleType"/>
+            <xs:element name="InitialDetectorLatitude" type="AngleType"/>
+            <xs:element name="InitialDetectorLongitude" type="AngleType"/>
             <xs:element name="LowFrequency" type="FreqType"/>
             <xs:element name="HighFrequency" type="FreqType"/>
             <xs:element name="SNRThreshold" type="xs:decimal"/>

--- a/src/nuspacesim/xml_config/parse_config.py
+++ b/src/nuspacesim/xml_config/parse_config.py
@@ -110,8 +110,8 @@ def parse_detector_chars(xmlfile: str) -> DetectorCharacteristics:
         # Convert Degrees to Radians
         if "Unit" in node.attrib:
             if node.tag in [
-                "InitialDetectorRightAscension",
-                "InitialDetectorDeclination",
+                "InitialDetectorLatitude",
+                "InitialDetectorLongitude",
             ]:
                 x = float(node.text)
                 detchar[node.tag] = (
@@ -125,8 +125,8 @@ def parse_detector_chars(xmlfile: str) -> DetectorCharacteristics:
     return DetectorCharacteristics(
         method=detchar["Method"],
         altitude=float(detchar["DetectorAltitude"]),
-        ra_start=float(detchar["InitialDetectorRightAscension"]),
-        dec_start=float(detchar["InitialDetectorDeclination"]),
+        lat_start=float(detchar["InitialDetectorLatitude"]),
+        long_start=float(detchar["InitialDetectorLongitude"]),
         telescope_effective_area=float(detchar["TelescopeEffectiveArea"]),
         quantum_efficiency=float(detchar["QuantumEfficiency"]),
         photo_electron_threshold=float(detchar["NPE"]),
@@ -286,13 +286,13 @@ def create_xml(filename: str, config: NssConfig = NssConfig()) -> None:
     detalt.set("Unit", "km")
     detalt.text = str(config.detector.altitude)
 
-    detra = ET.SubElement(detchar, "InitialDetectorRightAscension")
-    detra.set("Unit", "Degrees")
-    detra.text = str(config.detector.ra_start)
+    detlat = ET.SubElement(detchar, "InitialDetectorLatitude")
+    detlat.set("Unit", "Degrees")
+    detlat.text = str(config.detector.lat_start)
 
-    detdec = ET.SubElement(detchar, "InitialDetectorDeclination")
-    detdec.set("Unit", "Degrees")
-    detdec.text = str(config.detector.dec_start)
+    detlong = ET.SubElement(detchar, "InitialDetectorLongitude")
+    detlong.set("Unit", "Degrees")
+    detlong.text = str(config.detector.long_start)
 
     npe = ET.SubElement(pethres, "NPE")
     npe.text = str(config.detector.photo_electron_threshold)

--- a/test/simulation/geometry/_t_region_geometry.py
+++ b/test/simulation/geometry/_t_region_geometry.py
@@ -25,8 +25,8 @@ def test_rg():
 
     assert np.allclose(R.evArray["thetaS"][Rmsk], T.thetaS[Tmsk])
     assert np.allclose(R.evArray["phiS"][Rmsk], T.phiS[Tmsk])
-    assert np.allclose(R.evArray["raS"][Rmsk], T.raS[Tmsk])
-    assert np.allclose(R.evArray["decS"][Rmsk], T.decS[Tmsk])
+    assert np.allclose(R.evArray["latS"][Rmsk], T.latS[Tmsk])
+    assert np.allclose(R.evArray["longS"][Rmsk], T.longS[Tmsk])
     assert np.allclose(R.evArray["thetaTrSubV"][Rmsk], T.thetaTrSubV[Tmsk])
     assert np.allclose(R.evArray["costhetaTrSubV"][Rmsk], T.costhetaTrSubV[Tmsk])
     assert np.allclose(R.evArray["phiTrSubV"][Rmsk], T.phiTrSubV[Tmsk])
@@ -36,6 +36,8 @@ def test_rg():
     assert np.allclose(R.evArray["losPathLen"][Rmsk], T.losPathLen[Tmsk])
     assert np.allclose(R.evArray["thetaTrSubV"][Rmsk], T.thetaTrSubV[Tmsk])
     assert np.allclose(R.evArray["costhetaTrSubV"][Rmsk], T.costhetaTrSubV[Tmsk])
+    assert np.allclose(R.evArray["elevAngVSubN"][Rmsk], T.elevAngVSubN[Tmsk])
+    assert np.allclose(R.evArray["aziAngVSubN"][Rmsk], T.aziAngVSubN[Tmsk])
 
     assert not np.allclose(R.evArray["thetaS"][Rmsk], 1 + T.thetaS[Tmsk])
 

--- a/test/simulation/geometry/cpp_region_geometry.py
+++ b/test/simulation/geometry/cpp_region_geometry.py
@@ -52,8 +52,8 @@ class RegionGeom(Geom_params):
         super().__init__(
             radE=config.constants.earth_radius,
             detalt=config.detector.altitude,
-            detra=config.detector.ra_start,
-            detdec=config.detector.dec_start,
+            detlat=config.detector.lat_start,
+            detlong=config.detector.long_start,
             delAlpha=config.simulation.ang_from_limb,
             maxsepangle=config.simulation.theta_ch_max,
             delAziAng=config.simulation.max_azimuth_angle,


### PR DESCRIPTION
Summary:
* Changed ra_start and dec_start to long_start and lat_start
* Added variables for the lat-long of the spot on the ground and supporting variables for computing them
* Added function find_lat_long_along_traj for computing the lat-long of points along a trajectory as a function of distance (starting point is taken to be the spot on the ground)

The function takes as input a vector of distances that will be the same size as the masked vectors it uses (at least, that was the intent). Please check to make sure that this is what you were looking for and that it actually does what I think it does! ;)